### PR TITLE
Option to customize deploy branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ zrrvVLniH+UTjreQkhbFVqLPnL44+LIo30/oQJPISLxMYmZnuwudPN6O6ubyb8MK
 
 > :bulb: Tip : It is recommanded to use **GitHub Actions Secrets** to store sensible informations like SSH Keys
 
+***
+
+#### `deploy_branch`
+
+Optional. The branch to be deployed when pushing to Dokku (default to `master`). Useful when a [custom deploy branch](http://dokku.viewdocs.io/dokku/deployment/methods/git/#changing-the-deploy-branch) is set on Dokku.
+
+Example : `develop`
+
 ## Example usage 
 
 This action is particularly useful when triggered by new pushes :
@@ -58,5 +66,6 @@ jobs:
       with:
        dokku_repo: 'ssh://dokku@dokku.myhost.ca:22/appname'
        ssh_key: ${{ secrets.SSH_KEY }}
+       deploy_branch: 'develop'
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -12,9 +12,14 @@ inputs:
   ssh_key: 
     description: 'A private SSH key that has push acces to your Dokku instance'
     required: true
+  deploy_branch:
+    description: 'The branch to be deployed when pushing to Dokku (default: master)'
+    required: false
+    default: "master"
 runs:
   using: 'docker'
   image: 'Dockerfile'
   env:
     SSH_PRIVATE_KEY : ${{ inputs.ssh_key }}
     DOKKU_REPO : ${{ inputs.dokku_repo }}
+    DEPLOY_BRANCH : ${{ inputs.deploy_branch }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,7 @@ ssh-add /root/.ssh/id_rsa
 echo ""
 echo "Pushing to Dokku Host";
 
-git push $DOKKU_REPO HEAD:refs/heads/master --force
+git push $DOKKU_REPO $GITHUB_SHA:refs/heads/$DEPLOY_BRANCH --force
 
 [ $? -eq 0 ]  || exit 1
 


### PR DESCRIPTION
2 fixes here:
- push `$GITHUB_SHA` instead of `HEAD`. [`GITHUB_SHA`](help.github.com/en/actions/reference/events-that-trigger-workflows#push-event-push) refers to the actual commit being pushed when workflow is triggered, whereas the `HEAD` reference could move if multiple commits are pushed in rapid succession, resulting in a "wrong" commit being deployed.
- allow dokku to deploy to any branch, even when deploy branch is different than `master`, see http://dokku.viewdocs.io/dokku/deployment/methods/git/#changing-the-deploy-branch.

---

Also, I didn't add this to the PR because not sure if you want to reference other actions or not, but I think this would be a nice addition to the README (and it's zero-config).

Basically, there's [this GH Action](https://github.com/marketplace/actions/cancel-workflow-action) which cancels queued or in progress workflows whenever they're outdated. This could happen if a commit is pushed while a build is already ongoing. Instead of waiting for the current build to finish (which would already be outdated), it is canceled so the new build is processed immediately.

Let me know if you're ok I add this:

```diff
name: 'Deploy to my Dokku instance'

on:
  push:
    branches:
    - master

jobs:
  deploy:
    runs-on: ubuntu-latest
    steps:
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.4.0
+      with:
+        access_token: ${{ github.token }}
    
    - name: Cloning repo # This step is required
      uses: actions/checkout@v2

    # This step is required or you might get an error from Dokku
    - run: git fetch --prune --unshallow 
  
    - name: Push to dokku
      uses: obrassard/action-dokku-deploy@v1.0.0
      with:
       dokku_repo: 'ssh://dokku@dokku.myhost.ca:22/appname'
       ssh_key: ${{ secrets.SSH_KEY }}
       deploy_branch: 'develop'
```